### PR TITLE
Fixed composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "RSS builder for Laravel 4",
 	"keywords": ["rss", "laravel", "laravel4"],
     "license": "MIT",
-    "version": "1.0.0",
     "authors": [
         {
             "name": "thujohn",
@@ -18,6 +17,5 @@
         "psr-0": {
             "Thujohn\\Rss": "src/"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
You should never ever include "version" in your composer.json. It breaks everything. You will need to tag 1.0.2 after this otherwise people are stuck on 1.0.0.
