### PR TITLE
Add support of valid 'enclosure' element

### DIFF
--- a/src/Thujohn/Rss/Rss.php
+++ b/src/Thujohn/Rss/Rss.php
@@ -117,7 +117,14 @@ class Rss {
 				}
 				else
 				{
-					$elem_item->addChild($options[0], $vI);
+				    if (is_array($vI)) {
+		                        $item_child = $elem_item->addChild($options[0]);
+		                        foreach ($vI as $key => $value) {
+		                            $item_child->addAttribute($key, $value);
+		                        }
+		                    } else {
+		                        $elem_item->addChild($options[0], $vI);
+		                    }
 				}
 			}
 		}


### PR DESCRIPTION
Added support of 'enclosure' element with attributes.
Example:
`<enclosure url="https://funtime.kiev.ua/uploads/img/grid/middle/2016/03/holod-do-drozhi-vzaperti-kiev-kvest-komnata-56f95fdecc6c2.jpg" type="image/jpeg" length="74061"/>`

Code example:

```
$feed = new \Thujohn\Rss\Rss();
$feed->feed('2.0', 'UTF-8');
....
$item['enclosure'] = [
    'url'=> $image_url,
    'type' => mime_content_type($image_path),
    'length' => filesize($image_path)
];
$feed->item($item);
```
